### PR TITLE
fix(pulsar_client): improve the get_status mechanism

### DIFF
--- a/src/pulsar.appup.src
+++ b/src/pulsar.appup.src
@@ -1,6 +1,10 @@
-{"0.5.1",
+{"0.5.2",
    [
+     {"0.5.1", [
+       {load_module, pulsar_client, brutal_purge, soft_purge, []}
+     ]},
      {"0.5.0", [
+       {load_module, pulsar_client, brutal_purge, soft_purge, []},
        {load_module, pulsar_protocol_frame, brutal_purge, soft_purge, []},
        {load_module, pulsar_producers, brutal_purge, soft_purge, []},
        {load_module, pulsar_producer, brutal_purge, soft_purge, []},
@@ -9,7 +13,11 @@
      ]}
    ],
    [
+     {"0.5.1", [
+       {load_module, pulsar_client, brutal_purge, soft_purge, []}
+     ]},
      {"0.5.0", [
+       {load_module, pulsar_client, brutal_purge, soft_purge, []},
        {load_module, pulsar_protocol_frame, brutal_purge, soft_purge, []},
        {load_module, pulsar_producers, brutal_purge, soft_purge, []},
        {load_module, pulsar_producer, brutal_purge, soft_purge, []},


### PR DESCRIPTION
When checking status of pulsar, check the timestamp that the latest PONG received.