### PR TITLE
fix(producer): always lookup topic during startup

### DIFF
--- a/src/pulsar_client.erl
+++ b/src/pulsar_client.erl
@@ -255,8 +255,8 @@ handle_response({lookupTopicResponse, #{request_id := RequestId} = Response},
                     {#{enable_ssl := true}, #{brokerServiceUrlTls := BrokerServiceUrlTls}} ->
                         BrokerServiceUrlTls;
                     {#{enable_ssl := true}, #{brokerServiceUrl := BrokerServiceUrl}} ->
-                        log_error("SSL enabed but brokerServiceUrlTls is not provided by the puslar"
-                                  " server, fallback to use brokerServiceUrl: ~p", [BrokerServiceUrl]),
+                        log_error("SSL enabled but brokerServiceUrlTls is not provided by pulsar,"
+                                  " falling back to brokerServiceUrl: ~p", [BrokerServiceUrl]),
                         BrokerServiceUrl;
                     {_, #{brokerServiceUrl := BrokerServiceUrl}} ->
                         %% the 'brokerServiceUrl' is a mandatory field in case the SSL is disabled


### PR DESCRIPTION
If the network is partitioned when a producer is connected to Pulsar, but Pulsar itself doesn't go down, then there's no need to lookup the topic to which the producer will produce (as this is done by `pulsar_client`) prior to starting the producer the first time.

If, however, the Pulsar broker goes down and is later brought back up, the producer MUST lookup the topic again before sending any messages. Otherwise, Pulsar will reply with an error of the form:

```
Namespace bundle for topic (persistent://public/default/some-topic)
not served by this instance. Please redo the lookup. Request is
denied: namespace=public/default
```

Reference: https://pulsar.apache.org/docs/2.10.x/developing-binary-protocol/#topic-lookup