### PR TITLE
fix(producer): disconnect from broker if no pong is received within time frame

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     tty: true
 
   toxiproxy:
-    container_name: proxy
+    container_name: toxiproxy
     image: ghcr.io/shopify/toxiproxy
     ports:
       - 8474:8474
@@ -31,8 +31,10 @@ services:
       - 8080:8080
     restart: always
     command:
-      - bin/pulsar
-      - standalone
+      - bash
+      - "-c"
+      - |
+        bin/pulsar standalone
 
   pulsar-basic-auth:
     container_name: pulsar-basic-auth

--- a/test/pulsar_SUITE.erl
+++ b/test/pulsar_SUITE.erl
@@ -20,7 +20,7 @@
 
 -define(TEST_SUIT_CLIENT, client_erl_suit).
 -define(BATCH_SIZE , 100).
--define(PULSAR_HOST, "pulsar://pulsar:6650").
+-define(PULSAR_HOST, "pulsar://toxiproxy:6650").
 -define(PULSAR_BASIC_AUTH_HOST, "pulsar://pulsar-basic-auth:6650").
 -define(PULSAR_TOKEN_AUTH_HOST, "pulsar://pulsar-token-auth:6650").
 
@@ -71,7 +71,7 @@ end_per_suite(_Args) ->
 
 init_per_group(resilience, Config) ->
     PulsarHost = os:getenv("PULSAR_HOST", ?PULSAR_HOST),
-    ProxyHost = os:getenv("PROXY_HOST", "proxy"),
+    ProxyHost = os:getenv("PROXY_HOST", "toxiproxy"),
     ProxyPort = list_to_integer(os:getenv("PROXY_PORT", "8474")),
     UpstreamHost = os:getenv("PROXY_PULSAR_HOST", PulsarHost),
     %% when testing locally; externally exposed port for container
@@ -419,7 +419,7 @@ t_pulsar_drop_expired_batch(Config) ->
     %% here before producing the messages to avoid it hanging during
     %% the send, at which point the check for expiration was already
     %% done...
-    pulsar_test_utils:wait_for_state(ProducerPid, idle, _Retries = 15, _Sleep = 5_000),
+    pulsar_test_utils:wait_for_state(ProducerPid, idle, _Retries1 = 20, _Sleep1 = 5_000),
 
     %% Produce messages that'll expire
     ok = snabbkaffe:start_trace(),

--- a/test/pulsar_producer_SUITE.erl
+++ b/test/pulsar_producer_SUITE.erl
@@ -22,7 +22,7 @@
 -include_lib("common_test/include/ct.hrl").
 
 -define(TEST_SUIT_CLIENT, ?MODULE).
--define(DEFAULT_PULSAR_HOST, "pulsar://pulsar:6650").
+-define(DEFAULT_PULSAR_HOST, "pulsar://toxiproxy:6650").
 
 %%--------------------------------------------------------------------
 %% CT Boilerplate

--- a/test/test_SUITE_data/standalone.conf
+++ b/test/test_SUITE_data/standalone.conf
@@ -34,7 +34,9 @@ webServicePort=8080
 bindAddress=0.0.0.0
 
 # Hostname or IP address the service advertises to the outside world. If not set, the value of InetAddress.getLocalHost().getHostName() is used.
-advertisedAddress=pulsar
+advertisedAddress=toxiproxy
+
+advertisedListeners=toxiproxy:pulsar://toxiproxy:6650
 
 # Number of threads to use for Netty IO. Default is set to 2 * Runtime.getRuntime().availableProcessors()
 numIOThreads=


### PR DESCRIPTION
Attempt to fix resilience
test (`resilience.{timeout,down}.t_pulsar_drop_expired_batch`) and also to have a more consistent behavior.

Trying to fix CI for the changes introduced in #47 .