### PR TITLE
fix(producer): accumulate more overflowed requests before logging

### DIFF
--- a/src/pulsar_client.erl
+++ b/src/pulsar_client.erl
@@ -200,7 +200,7 @@ handle_info(ping, State = #state{sock = Sock, opts = Opts}) ->
     pulsar_socket:ping(Sock, Opts),
     {noreply, State, hibernate};
 handle_info(_Info, State) ->
-    log_error("receive unknown message: ~p", [_Info]),
+    log_error("received unknown message: ~p", [_Info]),
     {noreply, State, hibernate}.
 
 terminate(_Reason, #state{sock = undefined}) ->

--- a/src/pulsar_consumer.erl
+++ b/src/pulsar_consumer.erl
@@ -198,10 +198,10 @@ handle_response({message, Msg, Payloads}, State = #state{
             {keep_state, State}
     end;
 handle_response({close_consumer, #{}}, State = #state{partitiontopic = Topic}) ->
-    log_error("Close consumer: ~p~n", [Topic]),
+    log_error("Closed consumer: ~p~n", [Topic]),
     {stop, {shutdown, close_consumer}, State};
 handle_response(Msg, State) ->
-    log_error("Consumer Receive unknown message:~p~n", [Msg]),
+    log_error("Consumer received unknown message:~p~n", [Msg]),
     {keep_state, State}.
 
 start_keepalive() ->

--- a/test/pulsar_SUITE.erl
+++ b/test/pulsar_SUITE.erl
@@ -824,7 +824,6 @@ t_overflow(Config) ->
     ProxyHost = ?config(proxy_host, Config),
     ProxyPort = ?config(proxy_port, Config),
     ReplayqDir = ?config(replayq_dir, Config),
-    StabilizationPeriod = timer:seconds(15),
     {ok, _} = application:ensure_all_started(pulsar),
 
     {ok, _ClientPid} = pulsar:ensure_supervised_client(?TEST_SUIT_CLIENT, [PulsarHost], #{}),


### PR DESCRIPTION
To avoid excessive logging during high produce phases.  Otherwise, we were logging every overflowed batch.