### PR TITLE
fix(client): avoid client reaching maximum restart intensity during init

### DIFF
--- a/test/pulsar_test_utils.erl
+++ b/test/pulsar_test_utils.erl
@@ -103,3 +103,12 @@ wait_for_state(Pid, DesiredState, Retries, Sleep) ->
             ct:sleep(Sleep),
             wait_for_state(Pid, DesiredState, Retries - 1, Sleep)
     end.
+
+with_mock(Mod, FnName, MockedFn, Fun) ->
+    ok = meck:new(Mod, [non_strict, no_link, no_history, passthrough]),
+    ok = meck:expect(Mod, FnName, MockedFn),
+    try
+        Fun()
+    after
+        ok = meck:unload(Mod)
+    end.


### PR DESCRIPTION
If a client crashes and is later restarted by the supervisor while Pulsar is having a bad day (or the connection to it is), then it might reach maximum restart intensity and be removed from `pulsar_client_sup`.

Here, we retry the connection a few times, with a back-off time between attempts, before giving up to avoid this situation.