### PR TITLE
fix: report connection down when there are no producers/consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.8.1
+
+## Bug fixes
+
+- Fixed `pulsar_{producers,consumers}:all_connected/1` to return
+  `false` when there are no producer/consumer pids registered.
+  [#56](https://github.com/emqx/pulsar-client-erl/pull/56)
+
 # 0.8.0
 
 ## Enhancements

--- a/src/pulsar_consumers.erl
+++ b/src/pulsar_consumers.erl
@@ -56,11 +56,13 @@ stop_supervised(#{client := ClientId, name := Name}) ->
 all_connected(#{name := Name}) ->
     try
       ConsumerToPartitionTopicMap = gen_server:call(Name, get_consumers, 5_000),
-      lists:all(
-        fun(Pid) ->
-          connected =:= pulsar_consumer:get_state(Pid)
-        end,
-        maps:keys(ConsumerToPartitionTopicMap))
+      NumConsumers = map_size(ConsumerToPartitionTopicMap),
+      (NumConsumers =/= 0) andalso
+          lists:all(
+            fun(Pid) ->
+                    connected =:= pulsar_consumer:get_state(Pid)
+            end,
+            maps:keys(ConsumerToPartitionTopicMap))
     catch
         _:_ ->
             false

--- a/test/pulsar_echo_consumer.erl
+++ b/test/pulsar_echo_consumer.erl
@@ -5,6 +5,7 @@
 
 init(Topic, Args) ->
     SendTo = maps:get(send_to, Args),
+    SendTo ! {consumer_started, #{topic => Topic}},
     {ok, #{topic => Topic, send_to => SendTo}}.
 
 handle_message(Message, Payloads, State) ->

--- a/test/pulsar_test_utils.erl
+++ b/test/pulsar_test_utils.erl
@@ -91,6 +91,7 @@ wait_for_state(Pid, DesiredState, Retries, Sleep) ->
     Timeout = timer:seconds(11),
     try sys:get_state(Pid, Timeout) of
         {DesiredState, _} ->
+            ct:pal("~p reached desired ~p state", [Pid, DesiredState]),
             ok;
         State ->
             ct:pal("still not in current state;\n  current: ~p\n  process info: ~p\n  stacktrace: ~p",


### PR DESCRIPTION
Previously, an empty list of producers or consumers would make `pulsar_{producers,consumers}:all_connected/1` to return `true`.

Since there's currently no rebalance in Pulsar consumers, we should expect at least one consumer pid to exist as well.