### PR TITLE
fix(producer): fix race condition `case_clause` error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.8.3
+
+## Bug fixes
+
+- Fixed `case_clause` error in `pulsar_producer` that could be caused
+  by a connection failure to the Pulsar brokers depending on timing
+  and the precise state of the state machine.
+
 # 0.8.2
 
 ## Enhancements

--- a/src/pulsar_producer.erl
+++ b/src/pulsar_producer.erl
@@ -566,8 +566,9 @@ parse({Cmd, <<>>}, State) ->
 parse({Cmd, LastBin}, State) ->
     State2 = case handle_response(Cmd, State) of
         keep_state_and_data -> State;
-        {_, State1} -> State1;
-        {_, _, State1} -> State1
+        {_, State1 = #{}} -> State1;
+        {_, _NextState, State1 = #{}} -> State1;
+        {_, _NextState, State1 = #{}, _Actions} -> State1
     end,
     parse(pulsar_protocol_frame:parse(LastBin), State2).
 

--- a/test/pulsar_SUITE.erl
+++ b/test/pulsar_SUITE.erl
@@ -1104,8 +1104,8 @@ t_producers_all_connected(Config) ->
      end,
      ProducerPids),
     ?retry(
-       _Sleep = 300,
-       _Attempts = 20,
+       _Sleep1 = 500,
+       _Attempts1 = 20,
        ?assert(pulsar_producers:all_connected(Producers))),
     %% Should respond even if producers are busy.
     lists:foreach(fun sys:suspend/1, ProducerPids),
@@ -1116,8 +1116,8 @@ t_producers_all_connected(Config) ->
     lists:foreach(fun(P) -> exit(P, kill) end, ProducerPids),
     wait_until_all_dead(Refs, 5_000),
     ?retry(
-       _Sleep = 300,
-       _Attempts = 20,
+       _Sleep2 = 500,
+       _Attempts2 = 20,
        ?assertNot(pulsar_producers:all_connected(Producers))),
     ok.
 


### PR DESCRIPTION
Depending on the precise state of the state machine, if a connection failure would occur while parsing a response from Pulsar broker, one could reach a `case_clause` error when the result of `handle_response` would be of the form:

```
{next_state,idle,#{...},[{state_timeout,5000,do_connect}]}
```