### PR TITLE
fix: restart `pulsar_producers` if it encounters problems reaching `pulsar_client`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 - Fixed an issue where `pulsar_producers` would stop and not restart if it encountered
   problems when trying to reach `pulsar_client`.
 
+# 0.8.4
+
+## Bug fixes
+
+- Fixed an issue where a producer process might've end up stuck with a closed connection
+  while it believed to be in the `connected` state.
+
 # 0.8.3
 
 ## Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.8.5
+
+## Bug fixes
+
+- Fixed an issue where `pulsar_producers` would stop and not restart if it encountered
+  problems when trying to reach `pulsar_client`.
+
 # 0.8.3
 
 ## Bug fixes

--- a/src/pulsar_producers.erl
+++ b/src/pulsar_producers.erl
@@ -173,10 +173,10 @@ handle_info(timeout, State = #state{client_id = ClientId, topic = Topic}) ->
                     {noreply, NewState#state{partitions = length(PartitionTopics)}};
                 {error, Reason} ->
                     log_error("get topic metatdata failed: ~p", [Reason]),
-                    {stop, {shutdown, Reason}, State}
+                    {stop, {failed_to_get_metadata, Reason}, State}
             end;
         {error, Reason} ->
-            {stop, {shutdown, Reason}, State}
+            {stop, {client_not_found, Reason}, State}
     end;
 handle_info({'EXIT', Pid, Error}, State = #state{workers = Workers, producers = Producers}) ->
     log_error("Received EXIT from ~p, error: ~p", [Pid, Error]),
@@ -195,7 +195,7 @@ handle_info({restart_producer, Partition, PartitionTopic}, State = #state{client
         {ok, Pid} ->
             {noreply, start_producer(Pid, Partition, PartitionTopic, State)};
         {error, Reason} ->
-            {stop, {shutdown, Reason}, State}
+            {stop, {client_not_found, Reason}, State}
     end;
 handle_info({producer_state_change, ProducerPid, ProducerState},
             State = #state{producers = Producers, workers = WorkersTable})


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13230

https://github.com/emqx/pulsar-client-erl/blob/02ddfa49c24ea205bceb076f7286fcfa7d9261de/src/pulsar_producers_sup.erl#L62

https://github.com/emqx/pulsar-client-erl/blob/02ddfa49c24ea205bceb076f7286fcfa7d9261de/src/pulsar_producers.erl#L176

https://github.com/emqx/pulsar-client-erl/blob/02ddfa49c24ea205bceb076f7286fcfa7d9261de/src/pulsar_producers.erl#L179

https://github.com/emqx/pulsar-client-erl/blob/02ddfa49c24ea205bceb076f7286fcfa7d9261de/src/pulsar_producers.erl#L198

```
2024-09-29T07:54:58.194786+00:00 [error] msg: resource_exception, mfa: emqx_resource_buffer_worker:handle_query_result_pure/3(899), peername: 10.236.106.0:26000, clientid: dfdf7791-755d-11ef-a2b7-0242ac130004, info: #{error => {error,badarg},id => <<"bridge:pulsar_producer:pulsar_332_edge">>,name => call_query_async,request => {send_message,#{<<"payload">> => <<"{\"errors\":{\"D016\":10003,\"D1010\":3007,\"D1110\":3007,\"D1210\":3007},\"group_name\":\"SUS\",\"metas\":{},\"node_name\":\"BC2310173\",\"timestamp\":1727596697404,\"values\":{\"D001\":\"\",\"D002\":\"\",\"D004\":\"\",\"D005\":\"\",\"D006\":0,\"D020\":0,\"D021\":0,\"D022\":\"\",\"D023\":0,\"D041\":0,\"D042\":0,\"D043\":0,\"D044\":0,\"D046\":0,\"D047\":0,\"D048\":0,\"D051\":0,\"D052\":0,\"D053\":0,\"D056\":0,\"D057\":0,\"D058\":0,\"D081\":0,\"D082\":0,\"D083"...>>,<<"topic">> => <<"toi/510/BC2310173">>}},stacktrace => [{ets,lookup,['producer-pulsar_producer:pulsar_332_edge:emqx@emqx-emqx-enterprise-0.emqx-emqx-enterprise-headless.emqx-enterprise.svc.cluster.local',0],[{error_info,#{cause => id,module => erl_stdlib_errors}}]},{pulsar_producers,lookup_producer,2,[{file,"pulsar_producers.erl"},{line,129}]},{pulsar_producers,do_pick_producer,4,[{file,"pulsar_producers.erl"},{line,98}]},{pulsar,send,3,[{file,"pulsar.erl"},{line,73}]},{emqx_resource_buffer_worker,apply_query_fun,9,[{file,"emqx_resource_buffer_worker.erl"},{line,1247}]},{emqx_resource_buffer_worker,simple_async_query,3,[{file,"emqx_resource_buffer_worker.erl"},{line,170}]},{emqx_rule_runtime,do_handle_action,4,[{file,"emqx_rule_runtime.erl"},{line,355}]},{emqx_rule_runtime,handle_action,4,[{file,"emqx_rule_runtime.erl"},{line,326}]},{emqx_rule_runtime,'-handle_action_list/4-lc$^0/1-0-',4,[{file,"emqx_rule_runtime.erl"},{line,321}]},{emqx_rule_runtime,do_apply_rule,3,[{file,"emqx_rule_runtime.erl"},{line,180}]},{emqx_rule_runtime,apply_rule,3,[{file,"emqx_rule_runtime.erl"},{line,72}]},{emqx_rule_runtime,apply_rule_discard_result,3,[{file,"emqx_rule_runtime.erl"},{line,65}]},{emqx_rule_runtime,apply_rules,3,[{file,"emqx_rule_runtime.erl"},{line,61}]},{emqx_rule_events,on_message_publish,2,[{file,"emqx_rule_events.erl"},{line,142}]},{emqx_hooks,safe_execute,2,[{file,"emqx_hooks.erl"},{line,205}]},{emqx_hooks,do_run_fold,3,[{file,"emqx_hooks.erl"},{line,185}]},{emqx_broker,publish,1,[{file,"emqx_broker.erl"},{line,229}]},{emqx_channel,do_publish,3,[{file,"emqx_channel.erl"},{line,685}]},{emqx_connection,with_channel,3,[{file,"emqx_connection.erl"},{line,840}]},{emqx_connection,process_msg,2,[{file,"emqx_connection.erl"},{line,493}]},{emqx_connection,process_msg,2,[{file,"emqx_connection.erl"},{line,499}]},{emqx_connection,handle_recv,3,[{file,"emqx_connection.erl"},{line,455}]},{proc_lib,wake_up,3,[{file,"proc_lib.erl"},{line,250}]}]}
2024-09-29T07:54:58.206994+00:00 [error] msg: failed_to_start_pulsar_producer, mfa:
emqx_bridge_pulsar_impl_producer:start_producer/4(365), instance_id:
<<"bridge:pulsar_producer:pulsar_io_331">>, kind: error, reason:
{badmatch,{error,not_running}}, stacktrace:
[{pulsar_producers,start_supervised,3,[{file,"pulsar_producers.erl"},{line,65}]},{emqx_bridge_pulsar_impl_producer,start_producer,4,[{file,"emqx_bridge_pulsar_impl_producer.erl"},{line,349}]},{emqx_resource,call_start,3,[{file,"emqx_resource.erl"},{line,518}]},{emqx_resource_manager,start_resource,2,[{file,"emqx_resource_manager.erl"},{line,599}]},{gen_statem,loop_state_callback,11,[{file,"gen_statem.erl"},{line,1428}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,240}]}]
```