### PR TITLE
fix: tcp opts order, move send/receive buffer opts to default

### DIFF
--- a/src/pulsar_socket.erl
+++ b/src/pulsar_socket.erl
@@ -46,12 +46,12 @@
     , {reuseaddr, true}
     , {active, true}
     , {reuseaddr, true}
-    , {sndbuf, 1_000_000}
-    , {recbuf, 1_000_000}
     ]).
 
 -define(DEF_TCP_OPTS,
     [ {nodelay, true}
+    , {sndbuf, 1_000_000}
+    , {recbuf, 1_000_000}
     , {send_timeout, ?SEND_TIMEOUT}
     ]).
 


### PR DESCRIPTION
`sndbuf` and `recbuf` options were added to the wrong place in #72