### PR TITLE
fix(frame): handle true single-message payloads when batch field is absent

### DIFF
--- a/src/pulsar_protocol_frame.erl
+++ b/src/pulsar_protocol_frame.erl
@@ -132,7 +132,15 @@ parse(<<TotalSize:32, CmdBin:TotalSize/binary, Rest/binary>>) ->
         ?MESSAGE ->
             <<MetadataSize:32, Metadata:MetadataSize/binary, Payload0/binary>> = CmdRest,
             MetadataCmd = pulsar_api:decode_msg(<<MetadataSize:32, Metadata/binary>>, 'MessageMetadata'),
-            Payloads = parse_batch_message(Payload0, maps:get(num_messages_in_batch, MetadataCmd, 1)),
+            %% If `num_messages_in_batch` is absent, this is a true single message
+            %% whose payload is sent directly (no SingleMessageMetadata wrapper).
+            %% If the key is present, parse as batch format (even when value = 1).
+            Payloads = case maps:is_key(num_messages_in_batch, MetadataCmd) of
+                false ->
+                    [Payload0];
+                true ->
+                    parse_batch_message(Payload0, maps:get(num_messages_in_batch, MetadataCmd))
+            end,
             {message, maps:get(message, BaseCommand), Payloads};
         ?CONNECTED ->
             {connected, maps:get(connected, BaseCommand)};

--- a/test/pulsar_protocol_frame_tests.erl
+++ b/test/pulsar_protocol_frame_tests.erl
@@ -1,0 +1,46 @@
+-module(pulsar_protocol_frame_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+parse_single_message_without_num_messages_in_batch_test() ->
+    Payload = <<"pulsar">>,
+    %% This metadata is captured from a real broker response where
+    %% `num_messages_in_batch` is absent.
+    Metadata = <<10, 14, 115, 116, 97, 110, 100, 97, 108, 111, 110, 101, 45,
+                 48, 45, 56, 16, 0, 24, 205, 234, 247, 203, 187, 50, 72, 6>>,
+    Packet = message_packet(Metadata, Payload),
+    {{message, _MsgInfo, Payloads}, <<>>} = pulsar_protocol_frame:parse(Packet),
+    ?assertEqual([Payload], Payloads).
+
+parse_batch_message_when_num_messages_in_batch_present_test() ->
+    Payload = <<"pulsar">>,
+    BatchPayload = batch_payload(Payload),
+    Metadata = pulsar_api:encode_msg(
+        #{
+            producer_name => "standalone-0-8",
+            sequence_id => 0,
+            publish_time => 12345,
+            uncompressed_size => byte_size(Payload),
+            num_messages_in_batch => 1
+        },
+        'MessageMetadata'
+    ),
+    Packet = message_packet(Metadata, BatchPayload),
+    {{message, _MsgInfo, Payloads}, <<>>} = pulsar_protocol_frame:parse(Packet),
+    ?assertEqual([Payload], Payloads).
+
+batch_payload(Payload) ->
+    SingleMessageMetadata = pulsar_api:encode_msg(
+        #{payload_size => byte_size(Payload)},
+        'SingleMessageMetadata'
+    ),
+    <<(byte_size(SingleMessageMetadata)):32, SingleMessageMetadata/binary, Payload/binary>>.
+
+message_packet(Metadata, Payload) ->
+    %% BaseCommand(Type=MESSAGE) + minimal CommandMessage
+    Command = <<8, 9, 74, 11, 8, 228, 2, 18, 6, 8, 13, 16, 0, 24, 4>>,
+    CommandSize = byte_size(Command),
+    MetadataSize = byte_size(Metadata),
+    TotalSize = 4 + CommandSize + 4 + MetadataSize + byte_size(Payload),
+    <<TotalSize:32, CommandSize:32, Command/binary,
+      MetadataSize:32, Metadata/binary, Payload/binary>>.


### PR DESCRIPTION
## Summary
Backport the single-message parsing fix to the `0.7.x` line.

When broker MESSAGE frames omit `num_messages_in_batch` (true non-batch format),
`pulsar_protocol_frame:parse/1` in 0.7.2 incorrectly tries batch parsing and can crash with:
- `{badmatch,<<"pulsar">>}`
- `{badmatch,<<"hello-pulsar">>}`

This patch keeps batch parsing when `num_messages_in_batch` is present,
and treats payload as a direct single message when the field is absent.

## Changes
- `src/pulsar_protocol_frame.erl`
  - distinguish “field absent” vs “field present (including value=1)”
- `test/pulsar_protocol_frame_tests.erl`
  - add regression test for true single-message payload
  - add test for batch payload with `num_messages_in_batch = 1`

## Backport Scope Conclusion
The 2.1.2 release includes additional producer-side changes (`pulsar_producer`,
`pulsar_socket`, `pulsar_socket_writer`) to optimize send behavior when `batch_size = 1`.

For EEC-1124, the failure path is consumer frame parsing (`pulsar_protocol_frame`) on
incoming broker MESSAGE frames. The crash is fully addressed by this parser fix.

Therefore, this backport is intentionally minimal and sufficient for EEC-1124,
while avoiding unrelated producer-side behavior changes in the 0.7.x line.

## Why now
This is needed by EMQX 4.4 backport work (EEC-1124) and is intended to support a `0.7.3` tag.

## Validation
- Compiled patched modules successfully.
- Reproduced the original crash against 0.7.2 with the real frame sample from EEC-1124.
- Verified the same frame parses successfully with this patch.
- Ran parse checks for both frame formats (single-message and batch).
